### PR TITLE
Load main menu after last level

### DIFF
--- a/Assets/Scripts/LevelLoader.cs
+++ b/Assets/Scripts/LevelLoader.cs
@@ -41,15 +41,17 @@ public class LevelLoader : MonoBehaviour
 
     public void LoadNextLevel()
     {
+        Time.timeScale = 1;
         int nextSceneIndex = SceneManager.GetActiveScene().buildIndex + 1;
 
         // if next scene index would exceed last scene in build settings
         if (nextSceneIndex > SceneManager.sceneCountInBuildSettings - 1)
         {
-            // load first scene instead
-            nextSceneIndex = 0;   
+            // Load Main Menu instead
+            SceneManager.LoadScene("Menu Screen");
+            return;
         }
-        
+
         StartCoroutine(LoadLevel(nextSceneIndex));
     }
 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,14 +6,14 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/Scenes/Menu Screen.unity
+    guid: 154d030118fdf3f42b659b9f9a89da1c
+  - enabled: 1
     path: Assets/Scenes/HowToPlay.unity
     guid: a3baba141652d1343bf7ba63719a82a9
   - enabled: 1
     path: Assets/Scenes/HowToPlayControls.unity
     guid: b863f4977cc70c04b8cbe7970797b41b
-  - enabled: 1
-    path: Assets/Scenes/Menu Screen.unity
-    guid: 154d030118fdf3f42b659b9f9a89da1c
   - enabled: 1
     path: Assets/Scenes/Hilly plane level 1.unity
     guid: 24c9e198b478c1149be22cc5696f1e7b


### PR DESCRIPTION
Made loading main menu after the last level more explicit. Also fixed the build order to make sure that the menu screen loads first on the standalone build.